### PR TITLE
Add teacher admin mode

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -5,7 +5,9 @@ A super simple FastAPI application that allows students to view and sign up for 
 ## Features
 
 - View all available extracurricular activities
-- Sign up for activities
+- View participant lists without logging in
+- Teachers can log in to sign students up for activities
+- Teachers can log students out of activities
 
 ## Getting Started
 
@@ -29,8 +31,12 @@ A super simple FastAPI application that allows students to view and sign up for 
 
 | Method | Endpoint                                                          | Description                                                         |
 | ------ | ----------------------------------------------------------------- | ------------------------------------------------------------------- |
+| POST   | `/auth/login`                                                     | Log in as a teacher and get a session token                         |
+| POST   | `/auth/logout`                                                    | End the current teacher session                                     |
+| GET    | `/auth/session`                                                   | Validate the active teacher session                                 |
 | GET    | `/activities`                                                     | Get all activities with their details and current participant count |
-| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign up for an activity                                             |
+| POST   | `/activities/{activity_name}/signup?email=student@mergington.edu` | Sign a student up for an activity as a teacher                      |
+| DELETE | `/activities/{activity_name}/unregister?email=student@mergington.edu` | Unregister a student from an activity as a teacher               |
 
 ## Data Model
 
@@ -48,3 +54,14 @@ The application uses a simple data model with meaningful identifiers:
    - Grade level
 
 All data is stored in memory, which means data will be reset when the server restarts.
+
+## Teacher Access
+
+Teacher usernames and password hashes are stored in `src/teachers.json`.
+
+Demo accounts included in this repository:
+
+- Username: `ms-johnson`
+- Password: `mergington123`
+- Username: `mr-lee`
+- Password: `clubadvisor`

--- a/src/app.py
+++ b/src/app.py
@@ -1,15 +1,16 @@
-"""
-High School Management System API
+"""High School Management System API."""
 
-A super simple FastAPI application that allows students to view and sign up
-for extracurricular activities at Mergington High School.
-"""
-
-from fastapi import FastAPI, HTTPException
-from fastapi.staticfiles import StaticFiles
-from fastapi.responses import RedirectResponse
+import hashlib
+import hmac
+import json
 import os
+import secrets
 from pathlib import Path
+
+from fastapi import Depends, FastAPI, Header, HTTPException
+from fastapi.responses import RedirectResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -18,6 +19,9 @@ app = FastAPI(title="Mergington High School API",
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+teachers_file = current_dir / "teachers.json"
+teacher_sessions = {}
 
 # In-memory activity database
 activities = {
@@ -78,9 +82,71 @@ activities = {
 }
 
 
+class TeacherLoginRequest(BaseModel):
+    username: str
+    password: str
+
+
+def hash_password(password: str) -> str:
+    return hashlib.sha256(password.encode("utf-8")).hexdigest()
+
+
+def load_teachers():
+    with teachers_file.open("r", encoding="utf-8") as file:
+        return json.load(file)["teachers"]
+
+
+def get_teacher_by_username(username: str):
+    teachers = load_teachers()
+    return next((teacher for teacher in teachers if teacher["username"] == username), None)
+
+
+def require_teacher(authorization: str = Header(default=None)):
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Teacher login required")
+
+    token = authorization.split(" ", 1)[1]
+    teacher = teacher_sessions.get(token)
+    if not teacher:
+        raise HTTPException(status_code=401, detail="Session expired or invalid")
+
+    return teacher
+
+
 @app.get("/")
 def root():
     return RedirectResponse(url="/static/index.html")
+
+
+@app.post("/auth/login")
+def login_teacher(credentials: TeacherLoginRequest):
+    teacher = get_teacher_by_username(credentials.username)
+    if not teacher:
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+
+    expected_hash = teacher["password_hash"]
+    if not hmac.compare_digest(expected_hash, hash_password(credentials.password)):
+        raise HTTPException(status_code=401, detail="Invalid username or password")
+
+    token = secrets.token_urlsafe(32)
+    teacher_data = {
+        "username": teacher["username"],
+        "display_name": teacher["display_name"],
+    }
+    teacher_sessions[token] = teacher_data
+    return {"token": token, "teacher": teacher_data}
+
+
+@app.post("/auth/logout")
+def logout_teacher(teacher=Depends(require_teacher), authorization: str = Header(default=None)):
+    token = authorization.split(" ", 1)[1]
+    teacher_sessions.pop(token, None)
+    return {"message": f"Logged out {teacher['display_name']}"}
+
+
+@app.get("/auth/session")
+def get_teacher_session(teacher=Depends(require_teacher)):
+    return {"teacher": teacher}
 
 
 @app.get("/activities")
@@ -89,8 +155,8 @@ def get_activities():
 
 
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
-    """Sign up a student for an activity"""
+def signup_for_activity(activity_name: str, email: str, teacher=Depends(require_teacher)):
+    """Sign up a student for an activity."""
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -107,12 +173,14 @@ def signup_for_activity(activity_name: str, email: str):
 
     # Add student
     activity["participants"].append(email)
-    return {"message": f"Signed up {email} for {activity_name}"}
+    return {
+        "message": f"{teacher['display_name']} signed up {email} for {activity_name}"
+    }
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
-    """Unregister a student from an activity"""
+def unregister_from_activity(activity_name: str, email: str, teacher=Depends(require_teacher)):
+    """Unregister a student from an activity."""
     # Validate activity exists
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
@@ -129,4 +197,6 @@ def unregister_from_activity(activity_name: str, email: str):
 
     # Remove student
     activity["participants"].remove(email)
-    return {"message": f"Unregistered {email} from {activity_name}"}
+    return {
+        "message": f"{teacher['display_name']} unregistered {email} from {activity_name}"
+    }

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -3,6 +3,104 @@ document.addEventListener("DOMContentLoaded", () => {
   const activitySelect = document.getElementById("activity");
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
+  const teacherMenuButton = document.getElementById("teacher-menu-button");
+  const teacherMenu = document.getElementById("teacher-menu");
+  const teacherStatus = document.getElementById("teacher-status");
+  const teacherLoginButton = document.getElementById("teacher-login-button");
+  const teacherLogoutButton = document.getElementById("teacher-logout-button");
+  const loginModal = document.getElementById("login-modal");
+  const closeLoginModal = document.getElementById("close-login-modal");
+  const loginForm = document.getElementById("login-form");
+  const loginMessage = document.getElementById("login-message");
+  const signupHelper = document.getElementById("signup-helper");
+
+  let teacherSession = null;
+
+  function authHeader() {
+    if (!teacherSession?.token) {
+      return {};
+    }
+
+    return {
+      Authorization: `Bearer ${teacherSession.token}`,
+    };
+  }
+
+  function authHeaderForToken(token) {
+    if (!token) {
+      return {};
+    }
+
+    return {
+      Authorization: `Bearer ${token}`,
+    };
+  }
+
+  function clearMessage(target) {
+    target.textContent = "";
+    target.className = "hidden";
+  }
+
+  function showMessage(target, text, type) {
+    target.textContent = text;
+    target.className = type;
+    target.classList.remove("hidden");
+  }
+
+  function saveTeacherSession(session) {
+    teacherSession = session;
+    localStorage.setItem("teacherSession", JSON.stringify(session));
+  }
+
+  function clearTeacherSession() {
+    teacherSession = null;
+    localStorage.removeItem("teacherSession");
+  }
+
+  function updateTeacherUi() {
+    const isLoggedIn = Boolean(teacherSession?.token);
+    teacherStatus.textContent = isLoggedIn
+      ? `Logged in as ${teacherSession.teacher.display_name}`
+      : "Viewing as student";
+    teacherLoginButton.classList.toggle("hidden", isLoggedIn);
+    teacherLogoutButton.classList.toggle("hidden", !isLoggedIn);
+    signupForm.classList.toggle("hidden", !isLoggedIn);
+    signupHelper.textContent = isLoggedIn
+      ? "Teachers can register or remove students from activities."
+      : "Teacher login required to register or remove students.";
+  }
+
+  async function restoreTeacherSession() {
+    const rawSession = localStorage.getItem("teacherSession");
+    if (!rawSession) {
+      updateTeacherUi();
+      return;
+    }
+
+    try {
+      const session = JSON.parse(rawSession);
+      const response = await fetch("/auth/session", {
+        headers: authHeaderForToken(session.token),
+      });
+
+      if (!response.ok) {
+        clearTeacherSession();
+        updateTeacherUi();
+        return;
+      }
+
+      const result = await response.json();
+      teacherSession = {
+        token: session.token,
+        teacher: result.teacher,
+      };
+      localStorage.setItem("teacherSession", JSON.stringify(teacherSession));
+    } catch (error) {
+      clearTeacherSession();
+    }
+
+    updateTeacherUi();
+  }
 
   // Function to fetch activities from API
   async function fetchActivities() {
@@ -12,6 +110,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
       // Clear loading message
       activitiesList.innerHTML = "";
+      activitySelect.innerHTML = '<option value="">-- Select an activity --</option>';
 
       // Populate activities list
       Object.entries(activities).forEach(([name, details]) => {
@@ -30,7 +129,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span>${teacherSession?.token ? `<button class="delete-btn" data-activity="${name}" data-email="${email}">Remove</button>` : ""}</li>`
                   )
                   .join("")}
               </ul>
@@ -69,6 +168,11 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // Handle unregister functionality
   async function handleUnregister(event) {
+    if (!teacherSession?.token) {
+      showMessage(messageDiv, "Teacher login required.", "error");
+      return;
+    }
+
     const button = event.target;
     const activity = button.getAttribute("data-activity");
     const email = button.getAttribute("data-email");
@@ -80,6 +184,7 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: authHeader(),
         }
       );
 
@@ -114,6 +219,11 @@ document.addEventListener("DOMContentLoaded", () => {
   signupForm.addEventListener("submit", async (event) => {
     event.preventDefault();
 
+    if (!teacherSession?.token) {
+      showMessage(messageDiv, "Teacher login required.", "error");
+      return;
+    }
+
     const email = document.getElementById("email").value;
     const activity = document.getElementById("activity").value;
 
@@ -124,6 +234,7 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: authHeader(),
         }
       );
 
@@ -155,6 +266,85 @@ document.addEventListener("DOMContentLoaded", () => {
     }
   });
 
+  teacherMenuButton.addEventListener("click", () => {
+    teacherMenu.classList.toggle("hidden");
+  });
+
+  teacherLoginButton.addEventListener("click", () => {
+    clearMessage(loginMessage);
+    teacherMenu.classList.add("hidden");
+    loginModal.classList.remove("hidden");
+  });
+
+  closeLoginModal.addEventListener("click", () => {
+    loginModal.classList.add("hidden");
+    loginForm.reset();
+    clearMessage(loginMessage);
+  });
+
+  teacherLogoutButton.addEventListener("click", async () => {
+    try {
+      await fetch("/auth/logout", {
+        method: "POST",
+        headers: authHeader(),
+      });
+    } catch (error) {
+      console.error("Error logging out:", error);
+    }
+
+    clearTeacherSession();
+    updateTeacherUi();
+    teacherMenu.classList.add("hidden");
+    showMessage(messageDiv, "Logged out successfully.", "success");
+    fetchActivities();
+  });
+
+  loginForm.addEventListener("submit", async (event) => {
+    event.preventDefault();
+
+    const username = document.getElementById("username").value.trim();
+    const password = document.getElementById("password").value;
+
+    try {
+      const response = await fetch("/auth/login", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ username, password }),
+      });
+      const result = await response.json();
+
+      if (!response.ok) {
+        showMessage(loginMessage, result.detail || "Login failed.", "error");
+        return;
+      }
+
+      saveTeacherSession(result);
+      updateTeacherUi();
+      loginModal.classList.add("hidden");
+      loginForm.reset();
+      clearMessage(loginMessage);
+      showMessage(messageDiv, `Welcome, ${result.teacher.display_name}.`, "success");
+      fetchActivities();
+    } catch (error) {
+      showMessage(loginMessage, "Failed to sign in. Please try again.", "error");
+      console.error("Error logging in:", error);
+    }
+  });
+
+  document.addEventListener("click", (event) => {
+    if (!teacherMenu.contains(event.target) && event.target !== teacherMenuButton) {
+      teacherMenu.classList.add("hidden");
+    }
+
+    if (event.target === loginModal) {
+      loginModal.classList.add("hidden");
+      loginForm.reset();
+      clearMessage(loginMessage);
+    }
+  });
+
   // Initialize app
-  fetchActivities();
+  restoreTeacherSession().then(fetchActivities);
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -8,8 +8,20 @@
   </head>
   <body>
     <header>
-      <h1>Mergington High School</h1>
-      <h2>Extracurricular Activities</h2>
+      <div class="header-top-row">
+        <div>
+          <h1>Mergington High School</h1>
+          <h2>Extracurricular Activities</h2>
+        </div>
+        <div class="teacher-controls">
+          <button id="teacher-menu-button" class="icon-button" type="button" aria-label="Teacher menu">👤</button>
+          <div id="teacher-menu" class="teacher-menu hidden">
+            <p id="teacher-status">Viewing as student</p>
+            <button id="teacher-login-button" type="button">Teacher Login</button>
+            <button id="teacher-logout-button" class="secondary-action hidden" type="button">Logout</button>
+          </div>
+        </div>
+      </div>
     </header>
 
     <main>
@@ -22,7 +34,8 @@
       </section>
 
       <section id="signup-container">
-        <h3>Sign Up for an Activity</h3>
+        <h3>Register Student for an Activity</h3>
+        <p id="signup-helper" class="helper-text">Teacher login required to register or remove students.</p>
         <form id="signup-form">
           <div class="form-group">
             <label for="email">Student Email:</label>
@@ -41,8 +54,30 @@
       </section>
     </main>
 
+    <div id="login-modal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="login-title">
+      <div class="modal-card">
+        <div class="modal-header">
+          <h3 id="login-title">Teacher Login</h3>
+          <button id="close-login-modal" class="icon-button" type="button" aria-label="Close login">✕</button>
+        </div>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="username">Username:</label>
+            <input type="text" id="username" required placeholder="ms-johnson" />
+          </div>
+          <div class="form-group">
+            <label for="password">Password:</label>
+            <input type="password" id="password" required placeholder="Enter teacher password" />
+          </div>
+          <div id="login-message" class="hidden"></div>
+          <button type="submit">Sign In</button>
+        </form>
+      </div>
+    </div>
+
     <footer>
       <p>&copy; 2026 Mergington High School</p>
+      <p class="footer-note">Demo teacher accounts are managed in src/teachers.json.</p>
     </footer>
 
     <script src="app.js"></script>

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -16,12 +16,65 @@ body {
 }
 
 header {
-  text-align: center;
   padding: 20px 0;
   margin-bottom: 30px;
   background-color: #1a237e;
   color: white;
   border-radius: 5px;
+}
+
+.header-top-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 0 20px;
+}
+
+.teacher-controls {
+  position: relative;
+}
+
+.icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 999px;
+  font-size: 18px;
+  padding: 0;
+}
+
+.teacher-menu {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  width: 220px;
+  background-color: white;
+  color: #333;
+  border-radius: 8px;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.18);
+  padding: 12px;
+  z-index: 20;
+}
+
+.teacher-menu p {
+  margin-bottom: 12px;
+}
+
+.teacher-menu button,
+.secondary-action {
+  width: 100%;
+}
+
+.secondary-action {
+  margin-top: 8px;
+  background-color: #455a64;
+}
+
+.secondary-action:hover {
+  background-color: #546e7a;
 }
 
 header h1 {
@@ -55,6 +108,11 @@ section h3 {
   padding-bottom: 10px;
   border-bottom: 1px solid #ddd;
   color: #1a237e;
+}
+
+.helper-text {
+  margin-bottom: 16px;
+  color: #455a64;
 }
 
 .activity-card {
@@ -111,18 +169,18 @@ section h3 {
 }
 
 .delete-btn {
-  background: none;
+  background-color: #c62828;
+  color: white;
   border: none;
-  color: #c62828;
   cursor: pointer;
-  font-size: 14px;
-  padding: 2px 5px;
+  font-size: 13px;
+  padding: 6px 10px;
   transition: all 0.2s;
   border-radius: 3px;
 }
 
 .delete-btn:hover {
-  background-color: #ffebee;
+  background-color: #b71c1c;
 }
 
 .participants-section p {
@@ -192,9 +250,61 @@ button:hover {
   display: none;
 }
 
+.modal {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(26, 35, 126, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  z-index: 50;
+}
+
+.modal-card {
+  width: min(100%, 420px);
+  background-color: white;
+  border-radius: 12px;
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.25);
+  padding: 20px;
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.modal-header .icon-button {
+  width: 36px;
+  height: 36px;
+  font-size: 16px;
+}
+
 footer {
   text-align: center;
   margin-top: 30px;
   padding: 20px;
   color: #666;
+}
+
+.footer-note {
+  margin-top: 6px;
+  font-size: 14px;
+}
+
+@media (max-width: 767px) {
+  .header-top-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .teacher-controls {
+    align-self: flex-end;
+  }
+
+  section {
+    max-width: 100%;
+  }
 }

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,14 @@
+{
+  "teachers": [
+    {
+      "username": "ms-johnson",
+      "display_name": "Ms. Johnson",
+      "password_hash": "870c14521511d57c5b981687a6174f6a1a6ab193cc02b91722cdb3b2dbc28d03"
+    },
+    {
+      "username": "mr-lee",
+      "display_name": "Mr. Lee",
+      "password_hash": "c52b2b123abb53589085754a44fa70b9c9bbd0bab6fe6f978dd1936b3cb329e2"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Implements issue #5 by introducing a simple teacher-only admin mode for student registration management.

### What changed

- Added teacher login, logout, and session validation endpoints
- Restricted signup and unregister endpoints to authenticated teachers
- Added teacher credentials in `src/teachers.json`
- Added a teacher menu and login modal to the frontend
- Hid registration and removal actions unless a teacher is signed in
- Updated the project README with the new auth flow and demo accounts

### Validation

Tested locally with FastAPI running on port 8001:

- unauthenticated signup returns `401`
- valid teacher login succeeds
- authenticated signup succeeds
- logout succeeds
- previously issued token stops working after logout

Closes #5